### PR TITLE
change http to https on tracker server

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -1,4 +1,4 @@
-var SERVER_URL = 'http://df58.host.cs.st-andrews.ac.uk/yahoogroups/'
+var SERVER_URL = 'https://df58.host.cs.st-andrews.ac.uk/yahoogroups/'
 var YAHOO_URL = 'https://groups.yahoo.com/neo/groups/<GROUP>/info'
 var YAHOO_SEARCH_URL = 'https://groups.yahoo.com/neo/search?query=<GROUP>'
 


### PR DESCRIPTION
- change the address of the tracker from http to https
- this should fix an issue where some versions of chrome reported the CORS header wasn't present, as on the http 301 redirect page, it indeed wasn't