### PR TITLE
Automatically clicks groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ See the instructions below on how to help.
 ### Using the Extension
 
 1. In Chrome's extension icons list in the top-right of the browser bar, click on the `Y`, ensure that the *Enabled* checkbox is ticked, then click *Start*.
-2. A tab will be opened with a Yahoo Groups *search results* page. There should be a group highlighted with a red border. Click on that group (it'll open in a new tab).
+2. A tab will be opened with a Yahoo Groups *search results* page. There should be a group highlighted with a red border. The extension will automatically start loading this group (though it might take a while with Yahoo's slow servers).
 3. Click the purple **+ Join Group** button in the centre-top right of the group page. (For foreign groups the name won't be *Join Group*, but it's the only purple button in that location).
 4. You'll get a pop-up with some default info already entered. **Do not change any of the information in this pop-up.**
 5. There will be a Google *I am not a robot* checkbox CAPTCHA in the pop-up. Complete it by clicking it and (most likely) identifying cars, buses, palm trees, or whatever else takes Google's fancy.
 6. Click the purple **Send Request** button at the bottom of the pop-up.
 7. The pop-up will close and the page will refresh to show the group homepage as seen by members. Congratulations - you've now joined the group and it'll most likely be saved. (Barring issues on our end, but that's our fault).
-8. Almost immediately the new tab will close and you'll be taken to another *search results* page. Proceed to step 2.
+8. Almost immediately, another *search results* page will start loading. Proceed to step 2.
 9. When you've had enough, click the `Y` in the top-right of the browser bar and uncheck the *Enabled* checkbox. Close the browser window.
 
 ### Private Groups

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Yahoo Groups Joiner",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "manifest_version": 2,
   "description": "Join all the (open) private Yahoo Groups",
   "background": {

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -2,6 +2,8 @@ var SERVER_URL = 'https://df58.host.cs.st-andrews.ac.uk/yahoogroups/'
 var YAHOO_URL = 'https://groups.yahoo.com/neo/groups/<GROUP>/info'
 var YAHOO_SEARCH_URL = 'https://groups.yahoo.com/neo/search?query=<GROUP>'
 
+var tabId = null;
+
 // on install, set enabled to false
 chrome.runtime.onInstalled.addListener(function (details) {
 	if (details.reason === 'install') {
@@ -55,7 +57,9 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       if (group === null) {
         return alert('no groups available')
       }
-      chrome.tabs.create({ url: group })
+      chrome.tabs.create({ url: group }, function(tab) {
+				tabId = tab.index;
+			});
     })
   }
 
@@ -78,9 +82,9 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
             if (url === null) {
               return alert('no more groups available')
             }
-            chrome.tabs.remove(sender.tab.id);
+            // chrome.tabs.remove(sender.tab.id);
             setTimeout(function() {
-              chrome.tabs.update(null, {url: url});
+              chrome.tabs.update(tabId, {url: url});
             }, 250);
           })
         }

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -2,8 +2,6 @@ var SERVER_URL = 'https://df58.host.cs.st-andrews.ac.uk/yahoogroups/'
 var YAHOO_URL = 'https://groups.yahoo.com/neo/groups/<GROUP>/info'
 var YAHOO_SEARCH_URL = 'https://groups.yahoo.com/neo/search?query=<GROUP>'
 
-var tabId = null;
-
 // on install, set enabled to false
 chrome.runtime.onInstalled.addListener(function (details) {
 	if (details.reason === 'install') {
@@ -57,9 +55,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       if (group === null) {
         return alert('no groups available')
       }
-      chrome.tabs.create({ url: group }, function(tab) {
-				tabId = tab.index;
-			});
+      chrome.tabs.create({ url: group });
     })
   }
 
@@ -84,7 +80,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
             }
             // chrome.tabs.remove(sender.tab.id);
             setTimeout(function() {
-              chrome.tabs.update(tabId, {url: url});
+              chrome.tabs.update(sender.tab.id, {url: url});
             }, 250);
           })
         }

--- a/src/inject/search.js
+++ b/src/inject/search.js
@@ -22,7 +22,9 @@ function run () {
       groupElementsCollection[i].style.border = '5px solid red';
 			var links = groupElementsCollection[i].getElementsByTagName('a');
 			if (links.length > 0) {
-				window.open(links[0].href, '_self');
+				setTimeout(function() {
+					window.open(links[0].href, '_self');
+				}, 250);
 			}
       found = true;
       break;
@@ -40,5 +42,7 @@ function run () {
   li.style.cursor = 'pointer';
   li.onclick = function() { window.open('groups/' + requiredGroup + '/info'); };
   groupList.insertBefore(li, groupList.firstChild);
-	li.click();
+	setTimeout(function() {
+		li.click();
+	}, 250);
 }

--- a/src/inject/search.js
+++ b/src/inject/search.js
@@ -40,7 +40,7 @@ function run () {
   li.style.fontWeight = 'bold';
   li.style.color = 'red';
   li.style.cursor = 'pointer';
-  li.onclick = function() { window.open('groups/' + requiredGroup + '/info'); };
+  li.onclick = function() { window.open('groups/' + requiredGroup + '/info', '_self'); };
   groupList.insertBefore(li, groupList.firstChild);
 	setTimeout(function() {
 		li.click();

--- a/src/inject/search.js
+++ b/src/inject/search.js
@@ -20,6 +20,10 @@ function run () {
     var gname = groupElementsCollection[i].getAttribute('data-gname').toLowerCase()
     if (gname === requiredGroup.toLowerCase()) {
       groupElementsCollection[i].style.border = '5px solid red';
+			var links = groupElementsCollection[i].getElementsByTagName('a');
+			if (links.length > 0) {
+				window.open(links[0].href, '_self');
+			}
       found = true;
       break;
     }
@@ -36,4 +40,5 @@ function run () {
   li.style.cursor = 'pointer';
   li.onclick = function() { window.open('groups/' + requiredGroup + '/info'); };
   groupList.insertBefore(li, groupList.firstChild);
+	li.click();
 }


### PR DESCRIPTION
This PR makes the process of joining groups a little bit quicker. When it's on the search page, it automatically clicks the link to the group after 250ms, which allows the user to multi-task while waiting on Yahoo's slow servers to load. Basically, you join a group, and then the extension will (eventually) load you directly into the next group. I also made it open the group link in the same tab as the search page, which allows the entire operation to run neatly in one tab.